### PR TITLE
Include additional log fields.

### DIFF
--- a/flask_request_logger/models.py
+++ b/flask_request_logger/models.py
@@ -1,7 +1,10 @@
+from datetime import datetime
+
 from sqlalchemy import Column, Integer, String, ForeignKey, DateTime
 from sqlalchemy.orm import relationship, backref
+
 from .database import Base
-from datetime import datetime
+
 
 class RequestLog(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
@@ -15,9 +18,8 @@ class RequestLog(Base):
     def __init__(self, method, url, content_length, remote_addr, user_agent):
         self.method = method
         self.url = url
-        self.content_length = content_length 
-        # Current time normalized as UTC
-        self.timestamp = datetime.utcnow()            
+        self.content_length = content_length
+        self.timestamp = datetime.utcnow()  # Current time normalized as UTC         
         self.remote_addr = remote_addr
         self.user_agent = user_agent.string
 

--- a/flask_request_logger/models.py
+++ b/flask_request_logger/models.py
@@ -1,30 +1,39 @@
-from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime
 from sqlalchemy.orm import relationship, backref
 from .database import Base
-
+from datetime import datetime
 
 class RequestLog(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
+    timestamp = Column(DateTime)
     method = Column(String(50))
-    url = Column(String(120))
+    url = Column(String(255))
     content_length = Column(Integer, nullable=True)
+    remote_addr = Column(String(50))
+    user_agent = Column(String(255))
 
-    def __init__(self, method, url, content_length):
+    def __init__(self, method, url, content_length, remote_addr, user_agent):
         self.method = method
         self.url = url
-        self.content_length = content_length
+        self.content_length = content_length 
+        # Current time normalized as UTC
+        self.timestamp = datetime.utcnow()            
+        self.remote_addr = remote_addr
+        self.user_agent = user_agent.string
 
     def __repr__(self):
         return ("<{class_name}("
                 "id={self.id}, "
                 "method='{self.method}', "
                 "url='{self.url}', "
-                "content_length={self.content_length}"
+                "content_length={self.content_length}, "
+                "timestamp={self.timestamp}, "
+                "remote_addr='{self.remote_addr}', "
+                "user_agent='{self.user_agent}', "
                 ")>".format(
                     class_name=self.__class__.__name__,
                     self=self
                 ))
-
 
 class ResponseLog(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)

--- a/flask_request_logger/request_logger.py
+++ b/flask_request_logger/request_logger.py
@@ -56,7 +56,7 @@ class RequestLogger(object):
         return db_session
 
     def _logging_req_resp(self, response):
-        req_log = RequestLog(request.method, request.url, request.content_length)
+        req_log = RequestLog(request.method, request.url, request.content_length, request.remote_addr, request.user_agent)
         self.db.add(req_log)
         self.db.commit()
         res_log = ResponseLog(response.status_code, response.content_length, req_log.id)


### PR DESCRIPTION
HI there, I'm using your Flask extension so I thought it was useful to add more fields to the request log. I've included the typical data one finds in widespread log systems.  A couple of notes:

* Timestamp is normalised to UTC to cope with data coming from web server on a different geographic region. 
* URL field length was extended to be 255 char long (still a VARCHAR). When one deals with API's or search URL's is better to have more room.
