### PR TITLE
Fix docstrings to correct documentation rendering

### DIFF
--- a/flask_request_logger/api.py
+++ b/flask_request_logger/api.py
@@ -12,7 +12,7 @@ LOG.addHandler(logging.StreamHandler())
 class RequestLogAPI(MethodView):
     """
      | Extend from :class:`flask.views.MethodView`
-     | An API that mulipulate `request_log` table content.
+     | An API that manipulates `request_log` table content.
      | This API default added rules on endpoints **/req-log/**
     """
 
@@ -25,7 +25,7 @@ class RequestLogAPI(MethodView):
 class ResponseLogAPI(MethodView):
     """
      | Extend from :class:`flask.views.MethodView`
-     | An API that mulipulate `response_log` table content.
+     | An API that manipulates `response_log` table content.
      | This API default added rules on endpoints **/resp-log/**
     """
 


### PR DESCRIPTION
There were usages of `mulipulate` in place of `manipulates` in https://flask-request-logger.readthedocs.io/en/latest/api.html
These are the instances that were corrected.